### PR TITLE
nvidia-persistenced.service.template: Remove syslog.target

### DIFF
--- a/init/systemd/nvidia-persistenced.service.template
+++ b/init/systemd/nvidia-persistenced.service.template
@@ -26,7 +26,6 @@
 
 [Unit]
 Description=NVIDIA Persistence Daemon
-Wants=syslog.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
Remove syslog.target from service file, this target hasn't existed for over a decade.

https://github.com/systemd/systemd/blob/6aa8d43ade72e24c9426e604f7fc4b7582b9db7c/NEWS#L72-L73