### PR TITLE
Use input mtime as date in man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ $(OPTIONS_1_INC): $(GEN_MANPAGE_OPTS)
 $(MANPAGE_not_gzipped): nvidia-persistenced.1.m4 $(OPTIONS_1_INC) $(VERSION_MK)
 	$(call quiet_cmd,M4) -D__HEADER__=$(AUTO_TEXT) -I $(OUTPUTDIR) \
 	  -D__VERSION__=$(NVIDIA_VERSION) \
-	  -D__DATE__="`$(DATE) +%F`" \
+	  -D__DATE__="`$(DATE) -u -r nvidia-persistenced.1.m4 +%F || $(DATE) +%F`" \
 	  -D__BUILD_OS__=$(TARGET_OS) \
 	  $< > $@
 


### PR DESCRIPTION
same as https://github.com/NVIDIA/nvidia-xconfig/pull/3

Use input mtime as date in man page
See https://reproducible-builds.org/ for why this is good

This date call is designed to work with different flavors of 'date'.

This patch was done while working on reproducible builds for openSUSE, sponsored by the NLnet NGI0 fund.

