### PR TITLE
feat: adds option to run in foreground

### DIFF
--- a/nvidia-persistenced.h
+++ b/nvidia-persistenced.h
@@ -40,6 +40,7 @@ typedef struct {
     int verbose;
     uid_t uid;
     gid_t gid;
+    int foreground;
 } NvPdOptions;
 
 /* Command Implementations */

--- a/option-table.h
+++ b/option-table.h
@@ -111,5 +111,13 @@ static const NVGetoptOption __options[] = {
       "nvidia-persistenced where to look for this library (in case it cannot "
       "find it on its own). This option should normally not be needed." },
 
+    { "foreground",
+      'f',
+      NVGETOPT_HELP_ALWAYS,
+      NULL,
+      "Runs the process in the foreground instead of detaching. This is "
+      "useful for init systems that can't natively supervise processes "
+      "that detach themselves (e.g. runit)."},
+
     { NULL, 0, 0, NULL, NULL },
 };

--- a/options.c
+++ b/options.c
@@ -103,6 +103,7 @@ static void setup_option_defaults(NvPdOptions *options)
     options->verbose = 0;
     options->uid = getuid();
     options->gid = getgid();
+    options->foreground = 0;
 }
 
 /*
@@ -183,6 +184,9 @@ void parse_options(int argc, char *argv[], NvPdOptions *options)
                 break;
             case NVIDIA_CFG_PATH_OPTION:
                 options->nvidia_cfg_path = strval;
+                break;
+            case 'f':
+                options->foreground = 1;
                 break;
             default:
                 nv_error_msg("Invalid commandline, please run `%s --help` for "


### PR DESCRIPTION
Adds an `-f` / `--foreground` option that will prevent `nvidia-persistenced` from forking a background process. This is useful for init systems that can't natively supervise forked processes (e.g. runit).